### PR TITLE
Optimize drawing

### DIFF
--- a/source/engine/tpge/TPGE.cpp
+++ b/source/engine/tpge/TPGE.cpp
@@ -151,20 +151,15 @@ void tpge::CEngine::drawPixel(int x, int y, Uint32 color) {
 }
 
 void tpge::CEngine::blendPixel(int x, int y, float alpha, Uint32 color) {
-    for (int i = 0; i < m_PixelSize; i++) {
-        for (int j = 0; j < m_PixelSize; j++) {
-            Uint32 oldC = *((Uint32 *) ((Uint8 *) m_Surface->pixels + (y * m_PixelSize + i) * m_Surface->pitch +
-                                        (x * m_PixelSize + j) * 4));
+    Uint32 oldColor = *((Uint32 *) ((Uint8 *) m_Surface->pixels + (y * m_PixelSize) * m_Surface->pitch + (x * m_PixelSize) * 4));
+    Uint32 newColor = oldColor;
+    float inverseAlpha = 1 - alpha;
 
-            *((Uint8 *) m_Surface->pixels + (y * m_PixelSize + i) * m_Surface->pitch + (x * m_PixelSize + j) * 4 +
-              2) = (Uint8) (*((Uint8 *) (&color) + 2) * alpha + *((Uint8 *) (&oldC) + 2) * (1 - alpha));
-            *((Uint8 *) m_Surface->pixels + (y * m_PixelSize + i) * m_Surface->pitch + (x * m_PixelSize + j) * 4 +
-              1) = (Uint8) (*((Uint8 *) (&color) + 1) * alpha + *((Uint8 *) (&oldC) + 1) * (1 - alpha));
-            *((Uint8 *) m_Surface->pixels + (y * m_PixelSize + i) * m_Surface->pitch +
-              (x * m_PixelSize + j) * 4) = (Uint8) (*((Uint8 *) (&color) + 0) * alpha +
-                                                    *((Uint8 *) (&oldC)) * (1 - alpha));
-        }
-    }
+    *((Uint8 *) &newColor + 2) = (float)*((Uint8 *) &oldColor + 2) * inverseAlpha + (float)*((Uint8 *) &color + 2) * alpha;
+    *((Uint8 *) &newColor + 1) = (float)*((Uint8 *) &oldColor + 1) * inverseAlpha + (float)*((Uint8 *) &color + 1) * alpha;
+    *((Uint8 *) &newColor) = (float)*((Uint8 *) &oldColor) * inverseAlpha + (float)*((Uint8 *) &color) * alpha;
+
+    drawPixel(x, y, newColor);
 }
 
 void tpge::CEngine::blendScreen(float alpha, Uint32 color) {

--- a/source/engine/tpge/TPGE.cpp
+++ b/source/engine/tpge/TPGE.cpp
@@ -59,25 +59,17 @@ bool tpge::CEngine::construct(const char *title, unsigned width, unsigned height
 
     m_Title = title;
 
-//    m_Surface = SDL_GetWindowSurface(m_Window);
     m_KeyboardState = SDL_GetKeyboardState(nullptr);
-
-//    m_Overlay = SDL_CreateRGBSurface(0, m_Width * m_PixelSize, m_Height * m_PixelSize, m_Surface->format->BitsPerPixel,
-//                                     0, 0, 0, 0);
-//    SDL_SetSurfaceBlendMode(m_Overlay, SDL_BLENDMODE_BLEND);
-
-//    m_FullRect = SDL_Rect();
-//    m_FullRect.h = m_Height * m_PixelSize;
-//    m_FullRect.w = m_Width * m_PixelSize;
-//    m_FullRect.x = 0;
-//    m_FullRect.y = 0;
 
     m_Renderer = SDL_CreateRenderer(m_Window, -1, SDL_RENDERER_ACCELERATED);
     SDL_RenderSetLogicalSize(m_Renderer, m_Width, m_Height);
     SDL_RenderSetIntegerScale(m_Renderer, SDL_TRUE);
+
     m_ScreenTexture = SDL_CreateTexture(m_Renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, m_Width, m_Height);
+
     m_OverlayTexture = SDL_CreateTexture(m_Renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, m_Width, m_Height);
     SDL_SetTextureBlendMode(m_OverlayTexture, SDL_BLENDMODE_BLEND);
+
     m_Pixels = (Uint32 *)malloc(m_Width * m_Height * sizeof(Uint32));
 
     m_Root = true;
@@ -96,28 +88,14 @@ bool tpge::CEngine::inWindowOf(const tpge::CEngine &other) {
 
     m_Title = other.m_Title;
 
-//    m_Surface = SDL_GetWindowSurface(m_Window);
     m_KeyboardState = SDL_GetKeyboardState(nullptr);
 
-//    m_Overlay = SDL_CreateRGBSurface(0, m_Width * m_PixelSize, m_Height * m_PixelSize, m_Surface->format->BitsPerPixel,
-//                                     0, 0, 0, 0);
-//    SDL_SetSurfaceBlendMode(m_Overlay, SDL_BLENDMODE_BLEND);
-
-//    m_FullRect = SDL_Rect();
-//    m_FullRect.h = m_Height * m_PixelSize;
-//    m_FullRect.w = m_Width * m_PixelSize;
-//    m_FullRect.x = 0;
-//    m_FullRect.y = 0;
-
     m_Renderer = other.m_Renderer;
-//    SDL_RenderSetLogicalSize(m_Renderer, m_Width, m_Height);
+
     m_ScreenTexture = other.m_ScreenTexture;
     m_OverlayTexture = other.m_OverlayTexture;
-    m_Pixels = other.m_Pixels;
 
-//    m_Renderer = SDL_CreateRenderer(m_Window, -1, SDL_RENDERER_ACCELERATED);
-//    m_ScreenTexture = SDL_CreateTexture(m_Renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, m_Width * m_PixelSize, m_Height * m_PixelSize);
-//    m_Pixels = (Uint8 *)malloc(m_Width * m_Height * m_PixelSize * m_PixelSize * 4);
+    m_Pixels = other.m_Pixels;
 
     m_Root = false;
 
@@ -126,9 +104,6 @@ bool tpge::CEngine::inWindowOf(const tpge::CEngine &other) {
 
 
 void tpge::CEngine::destroy() {
-//    SDL_FreeSurface(m_Surface);
-//    SDL_FreeSurface(m_Overlay);
-
     SDL_DestroyWindow(m_Window);
     SDL_Quit();
 }

--- a/source/engine/tpge/TPGE.cpp
+++ b/source/engine/tpge/TPGE.cpp
@@ -73,8 +73,10 @@ bool tpge::CEngine::construct(const char *title, unsigned width, unsigned height
 //    m_FullRect.y = 0;
 
     m_Renderer = SDL_CreateRenderer(m_Window, -1, SDL_RENDERER_ACCELERATED);
-    m_ScreenTexture = SDL_CreateTexture(m_Renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, m_Width * m_PixelSize, m_Height * m_PixelSize);
-    m_Pixels = (Uint8 *)malloc(m_Width * m_Height * m_PixelSize * m_PixelSize * 4);
+    SDL_RenderSetLogicalSize(m_Renderer, m_Width, m_Height);
+    SDL_RenderSetIntegerScale(m_Renderer, SDL_TRUE);
+    m_ScreenTexture = SDL_CreateTexture(m_Renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, m_Width, m_Height);
+    m_Pixels = (Uint8 *)malloc(m_Width * m_Height * 4);
 
     m_Root = true;
 
@@ -106,6 +108,7 @@ bool tpge::CEngine::inWindowOf(const tpge::CEngine &other) {
 //    m_FullRect.y = 0;
 
     m_Renderer = other.m_Renderer;
+//    SDL_RenderSetLogicalSize(m_Renderer, m_Width, m_Height);
     m_ScreenTexture = other.m_ScreenTexture;
     m_Pixels = other.m_Pixels;
 
@@ -128,7 +131,7 @@ void tpge::CEngine::destroy() {
 }
 
 void tpge::CEngine::printFrame() {
-    SDL_UpdateTexture(m_ScreenTexture, NULL, m_Pixels, m_Width * m_PixelSize * 4);
+    SDL_UpdateTexture(m_ScreenTexture, NULL, m_Pixels, m_Width * 4);
     SDL_RenderCopy(m_Renderer, m_ScreenTexture, NULL, NULL);
     SDL_RenderPresent(m_Renderer);
 //    SDL_UpdateWindowSurface(m_Window);
@@ -161,11 +164,7 @@ bool tpge::CEngine::isKeyPressed(SDL_Scancode key) {
 }
 
 void tpge::CEngine::drawPixel(int x, int y, Uint32 color) {
-    for (int i = 0; i < m_PixelSize; ++i) {
-        for (int j = 0; j < m_PixelSize; ++j) {
-            *((Uint32 *)&m_Pixels[(m_Width * m_PixelSize * (y * m_PixelSize + i)) * 4 + (x * m_PixelSize + j) * 4]) = color;
-        }
-    }
+    *((Uint32 *)&m_Pixels[m_Width * y * 4 + x * 4]) = color;
 //    SDL_Rect pixel{x * m_PixelSize, y * m_PixelSize, m_PixelSize, m_PixelSize};
 //    SDL_FillRect(m_Surface, &pixel, color);
 }

--- a/source/engine/tpge/TPGE.cpp
+++ b/source/engine/tpge/TPGE.cpp
@@ -146,12 +146,8 @@ bool tpge::CEngine::isKeyPressed(SDL_Scancode key) {
 }
 
 void tpge::CEngine::drawPixel(int x, int y, Uint32 color) {
-    for (int i = 0; i < m_PixelSize; i++) {
-        for (int j = 0; j < m_PixelSize; j++) {
-            *((Uint32 *) ((Uint8 *) m_Surface->pixels + (y * m_PixelSize + i) * m_Surface->pitch +
-                          (x * m_PixelSize + j) * 4)) = color;
-        }
-    }
+    SDL_Rect pixel{x * m_PixelSize, y * m_PixelSize, m_PixelSize, m_PixelSize};
+    SDL_FillRect(m_Surface, &pixel, color);
 }
 
 void tpge::CEngine::blendPixel(int x, int y, float alpha, Uint32 color) {

--- a/source/engine/tpge/TPGE.cpp
+++ b/source/engine/tpge/TPGE.cpp
@@ -59,18 +59,22 @@ bool tpge::CEngine::construct(const char *title, unsigned width, unsigned height
 
     m_Title = title;
 
-    m_Surface = SDL_GetWindowSurface(m_Window);
+//    m_Surface = SDL_GetWindowSurface(m_Window);
     m_KeyboardState = SDL_GetKeyboardState(nullptr);
 
-    m_Overlay = SDL_CreateRGBSurface(0, m_Width * m_PixelSize, m_Height * m_PixelSize, m_Surface->format->BitsPerPixel,
-                                     0, 0, 0, 0);
-    SDL_SetSurfaceBlendMode(m_Overlay, SDL_BLENDMODE_BLEND);
+//    m_Overlay = SDL_CreateRGBSurface(0, m_Width * m_PixelSize, m_Height * m_PixelSize, m_Surface->format->BitsPerPixel,
+//                                     0, 0, 0, 0);
+//    SDL_SetSurfaceBlendMode(m_Overlay, SDL_BLENDMODE_BLEND);
 
-    m_FullRect = SDL_Rect();
-    m_FullRect.h = m_Height * m_PixelSize;
-    m_FullRect.w = m_Width * m_PixelSize;
-    m_FullRect.x = 0;
-    m_FullRect.y = 0;
+//    m_FullRect = SDL_Rect();
+//    m_FullRect.h = m_Height * m_PixelSize;
+//    m_FullRect.w = m_Width * m_PixelSize;
+//    m_FullRect.x = 0;
+//    m_FullRect.y = 0;
+
+    m_Renderer = SDL_CreateRenderer(m_Window, -1, SDL_RENDERER_ACCELERATED);
+    m_ScreenTexture = SDL_CreateTexture(m_Renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, m_Width * m_PixelSize, m_Height * m_PixelSize);
+    m_Pixels = (Uint8 *)malloc(m_Width * m_Height * m_PixelSize * m_PixelSize * 4);
 
     m_Root = true;
 
@@ -88,18 +92,26 @@ bool tpge::CEngine::inWindowOf(const tpge::CEngine &other) {
 
     m_Title = other.m_Title;
 
-    m_Surface = SDL_GetWindowSurface(m_Window);
+//    m_Surface = SDL_GetWindowSurface(m_Window);
     m_KeyboardState = SDL_GetKeyboardState(nullptr);
 
-    m_Overlay = SDL_CreateRGBSurface(0, m_Width * m_PixelSize, m_Height * m_PixelSize, m_Surface->format->BitsPerPixel,
-                                     0, 0, 0, 0);
-    SDL_SetSurfaceBlendMode(m_Overlay, SDL_BLENDMODE_BLEND);
+//    m_Overlay = SDL_CreateRGBSurface(0, m_Width * m_PixelSize, m_Height * m_PixelSize, m_Surface->format->BitsPerPixel,
+//                                     0, 0, 0, 0);
+//    SDL_SetSurfaceBlendMode(m_Overlay, SDL_BLENDMODE_BLEND);
 
-    m_FullRect = SDL_Rect();
-    m_FullRect.h = m_Height * m_PixelSize;
-    m_FullRect.w = m_Width * m_PixelSize;
-    m_FullRect.x = 0;
-    m_FullRect.y = 0;
+//    m_FullRect = SDL_Rect();
+//    m_FullRect.h = m_Height * m_PixelSize;
+//    m_FullRect.w = m_Width * m_PixelSize;
+//    m_FullRect.x = 0;
+//    m_FullRect.y = 0;
+
+    m_Renderer = other.m_Renderer;
+    m_ScreenTexture = other.m_ScreenTexture;
+    m_Pixels = other.m_Pixels;
+
+//    m_Renderer = SDL_CreateRenderer(m_Window, -1, SDL_RENDERER_ACCELERATED);
+//    m_ScreenTexture = SDL_CreateTexture(m_Renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, m_Width * m_PixelSize, m_Height * m_PixelSize);
+//    m_Pixels = (Uint8 *)malloc(m_Width * m_Height * m_PixelSize * m_PixelSize * 4);
 
     m_Root = false;
 
@@ -108,15 +120,18 @@ bool tpge::CEngine::inWindowOf(const tpge::CEngine &other) {
 
 
 void tpge::CEngine::destroy() {
-    SDL_FreeSurface(m_Surface);
-    SDL_FreeSurface(m_Overlay);
+//    SDL_FreeSurface(m_Surface);
+//    SDL_FreeSurface(m_Overlay);
 
     SDL_DestroyWindow(m_Window);
     SDL_Quit();
 }
 
 void tpge::CEngine::printFrame() {
-    SDL_UpdateWindowSurface(m_Window);
+    SDL_UpdateTexture(m_ScreenTexture, NULL, m_Pixels, m_Width * m_PixelSize * 4);
+    SDL_RenderCopy(m_Renderer, m_ScreenTexture, NULL, NULL);
+    SDL_RenderPresent(m_Renderer);
+//    SDL_UpdateWindowSurface(m_Window);
 }
 
 int tpge::CEngine::run() {
@@ -146,11 +161,17 @@ bool tpge::CEngine::isKeyPressed(SDL_Scancode key) {
 }
 
 void tpge::CEngine::drawPixel(int x, int y, Uint32 color) {
-    SDL_Rect pixel{x * m_PixelSize, y * m_PixelSize, m_PixelSize, m_PixelSize};
-    SDL_FillRect(m_Surface, &pixel, color);
+    for (int i = 0; i < m_PixelSize; ++i) {
+        for (int j = 0; j < m_PixelSize; ++j) {
+            *((Uint32 *)&m_Pixels[(m_Width * m_PixelSize * (y * m_PixelSize + i)) * 4 + (x * m_PixelSize + j) * 4]) = color;
+        }
+    }
+//    SDL_Rect pixel{x * m_PixelSize, y * m_PixelSize, m_PixelSize, m_PixelSize};
+//    SDL_FillRect(m_Surface, &pixel, color);
 }
 
 void tpge::CEngine::blendPixel(int x, int y, float alpha, Uint32 color) {
+    return;
     Uint32 oldColor = *((Uint32 *) ((Uint8 *) m_Surface->pixels + (y * m_PixelSize) * m_Surface->pitch + (x * m_PixelSize) * 4));
     Uint32 newColor = oldColor;
     float inverseAlpha = 1 - alpha;
@@ -163,6 +184,7 @@ void tpge::CEngine::blendPixel(int x, int y, float alpha, Uint32 color) {
 }
 
 void tpge::CEngine::blendScreen(float alpha, Uint32 color) {
+    return;
     SDL_FillRect(m_Overlay, nullptr, color);
     SDL_SetSurfaceAlphaMod(m_Overlay, (Uint8) (255 * alpha));
 
@@ -170,6 +192,7 @@ void tpge::CEngine::blendScreen(float alpha, Uint32 color) {
 }
 
 void tpge::CEngine::drawRectangle(int x, int y, int width, int height, Uint32 color) {
+    return;
     SDL_FillRect(m_Overlay, nullptr, color);
     SDL_Rect r;
     r.x = x * m_PixelSize;

--- a/source/engine/tpge/TPGE.h
+++ b/source/engine/tpge/TPGE.h
@@ -169,14 +169,19 @@ namespace tpge {
         unsigned m_Height;
         unsigned short m_PixelSize;
 
-        const char * m_Title;
+        const char *m_Title;
 
-        SDL_Window * m_Window;
-        SDL_Surface * m_Surface;
-        const Uint8 * m_KeyboardState;
+        SDL_Window *m_Window;
+        SDL_Surface *m_Surface;
+        SDL_Renderer *m_Renderer;
+        SDL_Texture *m_ScreenTexture;
 
-        SDL_Surface * m_Overlay;
+        Uint8 *m_Pixels;
+
+        SDL_Surface *m_Overlay;
         SDL_Rect m_FullRect;
+
+        const Uint8 *m_KeyboardState;
 
         static const uint16_t font[96][12];
     };

--- a/source/engine/tpge/TPGE.h
+++ b/source/engine/tpge/TPGE.h
@@ -175,10 +175,12 @@ namespace tpge {
         SDL_Surface *m_Surface;
         SDL_Renderer *m_Renderer;
         SDL_Texture *m_ScreenTexture;
+        SDL_Texture *m_OverlayTexture;
 
-        Uint8 *m_Pixels;
+        Uint32 *m_Pixels;
 
         SDL_Surface *m_Overlay;
+        bool m_IsOverlayOn;
         SDL_Rect m_FullRect;
 
         const Uint8 *m_KeyboardState;

--- a/source/engine/tpge/TPGE.h
+++ b/source/engine/tpge/TPGE.h
@@ -172,16 +172,12 @@ namespace tpge {
         const char *m_Title;
 
         SDL_Window *m_Window;
-        SDL_Surface *m_Surface;
         SDL_Renderer *m_Renderer;
         SDL_Texture *m_ScreenTexture;
         SDL_Texture *m_OverlayTexture;
-
         Uint32 *m_Pixels;
 
-        SDL_Surface *m_Overlay;
         bool m_IsOverlayOn;
-        SDL_Rect m_FullRect;
 
         const Uint8 *m_KeyboardState;
 


### PR DESCRIPTION
The engine is now using SDL accelerated renderer instead of blitting surfaces. The renderer also supports setting logical size for the lower resolutions with "bigger pixels". 